### PR TITLE
Permissions inheritance not working at all

### DIFF
--- a/src/IPub/Permissions/Entities/Role.php
+++ b/src/IPub/Permissions/Entities/Role.php
@@ -31,7 +31,7 @@ class Role extends Nette\Object implements IRole
 	/**
 	 * @var array
 	 */
-	protected $children;
+	protected $children = [];
 
 	/**
 	 * @var string
@@ -81,7 +81,11 @@ class Role extends Nette\Object implements IRole
 	 */
 	public function setChildren($roles)
 	{
-		$this->children[] = $roles;
+		if (!is_array($roles)) {
+			throw new Nette\InvalidArgumentException('You must provide array of children');
+		}
+
+		$this->children = array_merge($this->children, $roles);
 
 		return $this;
 	}

--- a/src/IPub/Permissions/Security/Permission.php
+++ b/src/IPub/Permissions/Security/Permission.php
@@ -63,6 +63,15 @@ class Permission extends NS\Permission implements NS\IAuthorizator
 
 			// & store role in object for future use
 			$this->roles[$role->getKeyName()] = $role;
+
+			$children = $role->getChildren();
+			if (!empty($children)) {
+				foreach ($children as $child) {
+					$child->setParent($role);
+					$this->removeRole($child->getKeyName());
+					$this->addRole($child->getKeyName(), $role->getKeyName());
+				}
+			}
 		}
 	}
 

--- a/src/IPub/Permissions/Security/Permission.php
+++ b/src/IPub/Permissions/Security/Permission.php
@@ -134,10 +134,6 @@ class Permission extends NS\Permission implements NS\IAuthorizator
 				// This combination role-resource-privilege is allowed
 				if ($role->hasPermission($permission)) {
 					$this->allow($role->getKeyName(), $resource, $privilege);
-
-				// This combination role-resource-privilege is not allowed
-				} else {
-					$this->deny($role->getKeyName(), $resource, $privilege);
 				}
 			}
 		}

--- a/src/IPub/Permissions/Security/Permission.php
+++ b/src/IPub/Permissions/Security/Permission.php
@@ -58,7 +58,8 @@ class Permission extends NS\Permission implements NS\IAuthorizator
 		// Register all available roles
 		foreach ($roles as $role) {
 			// Assign role to application permission checker
-			$this->addRole($role->getKeyName(), $role->getParent() ? $role->getParent()->getKeyName() : NULL);
+			$parent = $role->getParent();
+			$this->addRole($role->getKeyName(), ($parent) ? $parent->getKeyName() : NULL);
 
 			// & store role in object for future use
 			$this->roles[$role->getKeyName()] = $role;

--- a/tests/IPubTests/Permissions/InheritanceTest.phpt
+++ b/tests/IPubTests/Permissions/InheritanceTest.phpt
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Test: IPub\Permissions\Permissions
+ * @testCase
+ *
+ * @copyright	More in license.md
+ * @license		http://www.ipublikuj.eu
+ * @author		Igor Hlina http://www.srigi.sk
+ * @package		iPublikuj:Permissions!
+ * @subpackage	Tests
+ * @since		5.0
+ *
+ * @date		23.07.15
+ */
+
+namespace IPubTests\Permissions;
+
+use Nette;
+
+use Tester;
+use Tester\Assert;
+
+use IPub;
+use IPub\Permissions;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/RolesModel.php';
+
+class InheritanceTest extends Tester\TestCase
+{
+	/**
+	 * @var Permissions\Models\IRolesModel
+	 */
+	private $rolesModel;
+
+	/**
+	 * @var Permissions\Security\Permission
+	 */
+	private $permission;
+
+	/**
+	 * @return array[]|array
+	 */
+	public function dataValidPermissions()
+	{
+		return [
+			['firstResourceName:firstPrivilegeName', []],
+			[(new Permissions\Entities\Permission('secondResource', 'secondPrivilege', [])), NULL],
+			['thirdResourceName:thirdPrivilegeName', NULL],
+		];
+	}
+
+
+	/**
+	 * Set up
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+
+		$dic = $this->createContainer();
+
+		// Get roles model services
+		$this->rolesModel = $dic->getService('models.roles');
+
+		// Get permissions service
+		$this->permission = $dic->getService('permissions.permissions');
+
+		foreach ($this->dataValidPermissions() as list($permission, $details)) {
+			$this->permission->addPermission($permission, $details);
+		}
+	}
+
+
+	public function testPermissionChild()
+	{
+		Assert::true($this->permission->isAllowed('user-defined-child-role', 'firstResourceName', 'firstPrivilegeName'));
+	}
+
+
+	public function testPermissionInheritance()
+	{
+		Assert::true($this->permission->isAllowed('user-defined-role', 'firstResourceName', 'firstPrivilegeName'));
+		Assert::true($this->permission->isAllowed('user-defined-inherited-role', 'firstResourceName', 'firstPrivilegeName'));
+	}
+
+
+	/**
+	 * @return \SystemContainer|\Nette\DI\Container
+	 */
+	protected function createContainer()
+	{
+		$config = new Nette\Configurator();
+		$config->setTempDirectory(TEMP_DIR);
+
+		Permissions\DI\PermissionsExtension::register($config);
+
+		$config->addConfig(__DIR__ . '/files/config.neon', $config::NONE);
+
+		return $config->createContainer();
+	}
+}
+
+\run(new InheritanceTest());

--- a/tests/IPubTests/Permissions/InheritanceTest.phpt
+++ b/tests/IPubTests/Permissions/InheritanceTest.phpt
@@ -66,7 +66,8 @@ class InheritanceTest extends Tester\TestCase
 		// Get permissions service
 		$this->permission = $dic->getService('permissions.permissions');
 
-		foreach ($this->dataValidPermissions() as list($permission, $details)) {
+		foreach ($this->dataValidPermissions() as $permission) {
+			list($permission, $details) = $permission;
 			$this->permission->addPermission($permission, $details);
 		}
 	}

--- a/tests/IPubTests/Permissions/RolesModel.php
+++ b/tests/IPubTests/Permissions/RolesModel.php
@@ -68,7 +68,7 @@ class RolesModel implements Permissions\Models\IRolesModel
 			->setKeyName('user-defined-role')
 			->setName('Registered in custom role')
 			->setPriority(0)
-			->setChildren($customChild)
+			->setChildren([$customChild])
 			->setPermissions([
 				'firstResourceName:firstPrivilegeName',
 				'thirdResourceName:thirdPrivilegeName'

--- a/tests/IPubTests/Permissions/RolesModel.php
+++ b/tests/IPubTests/Permissions/RolesModel.php
@@ -57,20 +57,39 @@ class RolesModel implements Permissions\Models\IRolesModel
 				'thirdResourceName:thirdPrivilegeName'
 			]);
 
+		$customChild = (new Permissions\Entities\Role)
+			->setKeyName('user-defined-child-role')
+			->setName('Registered in custom role as children of another role')
+			->setPriority(0)
+			->setPermissions([
+			]);
+
 		$custom = (new Permissions\Entities\Role)
 			->setKeyName('user-defined-role')
 			->setName('Registered in custom role')
 			->setPriority(0)
+			->setChildren($customChild)
 			->setPermissions([
 				'firstResourceName:firstPrivilegeName',
 				'thirdResourceName:thirdPrivilegeName'
 			]);
 
+		$customInherited = (new Permissions\Entities\Role)
+			->setKeyName('user-defined-inherited-role')
+			->setName('Registered in custom role inheriting another role')
+			->setPriority(0)
+			->setParent($custom)
+			->setPermissions([
+			]);
+
+
 		return [
 			$guest,
 			$authenticated,
 			$administrator,
-			$custom
+			$customChild,
+			$custom,
+			$customInherited,
 		];
 	}
 }


### PR DESCRIPTION
I'm sending you failing tests for permissions inheritance.

Your `Permissions\Entities\Role` type has two methods: `setParent` and `setChildren`. Its obvious what this do - according role inherits permissions of another role. This is a must-have feature in ACL systems. In `IPub\Permissions` this is not working at all.

Fixing `setParent` should be easy - at `IPub\Permissions\Security\Permission::addPermission`  simply don't explicitly deny permission at line 139.

Fixing `setChildren` is tricky - you must correctly setup roles graph. I'm sending you this picture to illustrate what is by my opinion wrong.

![screen shot 2015-07-23 at 16 57 29](https://cloud.githubusercontent.com/assets/295197/8853951/97119baa-315d-11e5-9a7d-56005c0d9109.png)

As you can see `user-defined-role` has correctly define children, but `user-defined-child-role` doesn't have defined parent.
