### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/.travis.composer.php
+++ b/.travis.composer.php
@@ -10,7 +10,7 @@ echo "Nette version " . $version . PHP_EOL;
 
 $file = __DIR__ . '/composer.json';
 $content = file_get_contents($file);
-$composer = json_decode($content, TRUE);
+$composer = json_decode($content, true);
 
 $composer['require']['nette/application'] = $version;
 $composer['require']['nette/di'] = $version;


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!